### PR TITLE
Fix Vercel build errors by preventing build-time initialization of Stripe client

### DIFF
--- a/app/api/stripe/webhook/route.ts
+++ b/app/api/stripe/webhook/route.ts
@@ -17,8 +17,10 @@ export async function POST(req: NextRequest) {
   let event: Stripe.Event
 
   try {
+    const stripeClient = stripe()
+    
     // Verify webhook signature
-    event = stripe.webhooks.constructEvent(
+    event = stripeClient.webhooks.constructEvent(
       body,
       signature,
       process.env.STRIPE_WEBHOOK_SECRET!
@@ -203,12 +205,11 @@ async function handlePaymentSucceeded(invoice: Stripe.Invoice) {
     : subscriptionField?.id
   if (!subscriptionId) return
 
-  // Get subscription to get user_id
-  const subscription = await stripe.subscriptions.retrieve(subscriptionId)
+  const stripeClient = stripe()
+  const subscription = await stripeClient.subscriptions.retrieve(subscriptionId)
   const userId = subscription.metadata?.user_id
 
   if (userId) {
-    // Dynamically import database functions
     const { logEvent } = await import('@/lib/db')
 
     await logEvent('payment_succeeded', parseInt(userId), {
@@ -231,12 +232,11 @@ async function handlePaymentFailed(invoice: Stripe.Invoice) {
     : subscriptionField?.id
   if (!subscriptionId) return
 
-  // Get subscription to get user_id
-  const subscription = await stripe.subscriptions.retrieve(subscriptionId)
+  const stripeClient = stripe()
+  const subscription = await stripeClient.subscriptions.retrieve(subscriptionId)
   const userId = subscription.metadata?.user_id
 
   if (userId) {
-    // Dynamically import database functions
     const { logEvent } = await import('@/lib/db')
 
     await logEvent('payment_failed', parseInt(userId), {


### PR DESCRIPTION
# Hardening + Perf: Fix first-publish race, robust cache invalidation, webhook verification/dedup, rate limiting, and dashboard UX optimization

## Summary
This PR builds on the prior Vercel build fix and implements several bug fixes and optimizations across API routes, caching, Stripe webhooks, and the dashboard client.

What changed:
- First publish analytics correctness
  - Fixed a race in app/api/posts/publish/route.ts where “first_publish” could never fire. We now check for prior publishes before logging the current one, then emit “first_publish” only when appropriate.
- Cache correctness and performance
  - In lib/cache.ts increased default cache TTL from 5 minutes to 30 minutes.
  - Added clearCachePattern(prefix) and used it in publish/delete routes to invalidate all tier variants (posts:{owner}:{repo}:{tier}:...).
  - Introduced addUniqueKey(key, ttl) and rateLimitCheck(key, limit, window) helpers.
- Webhook hardening
  - app/api/stripe/webhook/route.ts now explicitly requires STRIPE_WEBHOOK_SECRET and fails fast if unset.
  - Added replay protection using addUniqueKey keyed by event.id with a 24h TTL (best-effort, in-memory).
  - Ensured constructEvent uses the validated webhookSecret.
- Abuse mitigation
  - Added simple per-IP rate limiting (10 req/min) to publish and delete API endpoints using in-memory buckets.
- GitHub traversal safety
  - lib/github.ts: getHugoPosts now has a maxDepth (default 10) in recursive traversal to avoid stack blowups on deeply nested trees.
- Dashboard UX optimization
  - components/dashboard-client.tsx: stop re-fetching all posts after publish/save/delete. Instead, optimistically update local state with the created/updated/deleted post, reducing network calls and improving responsiveness.
  - Prop cleanup: removed unused userId prop from DashboardClient and its caller (app/dashboard/page.tsx).
- Minor cleanup
  - Removed unused imports in lib/auth.ts and app/pricing/page.tsx.

Not included (proposed follow-ups):
- Batch GitHub file fetching (Tree API) and/or parallelization to reduce N+1 calls.
- Swap simple frontmatter parsing to js-yaml for more robust YAML handling.
- DB-backed webhook-event deduplication and rate limiting for global consistency across instances.
- Supabase indexes for hot columns.

## Review & Testing Checklist for Human
4 items to double-check and test:
- [ ] Stripe webhook behavior in a deployed environment:
      - Verify STRIPE_WEBHOOK_SECRET is required and that webhook signature verification succeeds via Stripe CLI.
      - Send the same event twice and confirm the second is treated as a duplicate (200 with no duplicate side-effects in DB/logs).
      - Confirm upgrade/downgrade/payment events still update user records as expected.
- [ ] Publish/delete flows and analytics:
      - Publish a new post and confirm “post_published” is logged and “first_publish” is logged only once for a new user.
      - Delete a post and confirm cache invalidation results in the dashboard reflecting the deletion without stale listings.
- [ ] Tiered cache invalidation:
      - If possible, test with a user switching tiers (free → paid). Confirm we invalidate all tier-specific cache keys and the dashboard shows the correct list size/permissions.
- [ ] Dashboard optimistic updates:
      - After publish/save/delete, ensure the client UI updates immediately without a roundtrip refetch and that the new post’s slug/title/path appear correctly.
      - Check edge case: publishing when no post is selected (new post) vs updating an existing selection.

Recommended test plan:
1) Local: npm run dev; authenticate; connect a test repo; publish a new post; verify dashboard list updates immediately; check Supabase analytics_events for “post_published” and “first_publish” behavior. Delete the post and verify the UI updates instantly.
2) Webhooks: use Stripe CLI (stripe listen … and stripe trigger) to send checkout.session.completed, customer.subscription.updated/deleted, and invoice.* events. Validate signature verification and duplicate suppression (send the same event ID twice).
3) Cache: publish/delete and then reload dashboard to ensure no stale results. If you can simulate tier changes, verify cache invalidation across tiers.
4) Rate limiting: hit publish/delete endpoints >10 times/min from the same IP and confirm 429s begin appearing.

### Notes
- In-memory NodeCache is per-process. Replay protection and rate limiting are best-effort and not globally consistent across instances. For production-grade guarantees, we should store event IDs and rate-limit counters in the database or a shared store (e.g., Redis).
- Build and typecheck pass. There are pre-existing lint issues in scripts/setup-stripe.js and a couple unused-var warnings unrelated to this PR.
- Link to Devin run: https://app.devin.ai/sessions/4e48109917024122b35f1f6ebb61f6ef
- Requested by: jmr (jacob@reider.us) / @jacobmr